### PR TITLE
allow to config autoconfirm of booking time

### DIFF
--- a/pass-fur-alle.js
+++ b/pass-fur-alle.js
@@ -16,7 +16,8 @@
     log('Set constants')
     var dateFrom = today();
     var dateTo = '2022-12-24';
-    
+    var autoConfirm = false;
+
     var datePickerElem = jQuery('#datepicker');
     if (!localStorage.getItem('TimeSearch')) {
         log('Set start date');
@@ -77,7 +78,7 @@
                     }
                     var responseText = jQuery('#selectionText').text() + ' ' + jQuery('#sectionSelectionText').text() + ' ' + timeSelectionText;
                     localStorage.setItem('responseText', responseText);
-                    if (confirm(responseText)) {
+                    if (autoConfirm || confirm(responseText)) {
                         jQuery('#booking-next').click();
                     }
                 } else {


### PR DESCRIPTION
For some the confirm doesn't show up, which makes you loose the selected time quickly.

This allows for config in the script to automatically click "next" as soon as a suitable time is found