### PR TITLE
Add SRI hash for jqurey-3.6.0.min.js

### DIFF
--- a/pass-fur-alle.js
+++ b/pass-fur-alle.js
@@ -6,7 +6,7 @@
 // @author       Jonk
 // @match        https://bokapass.nemoq.se/Booking/Booking/Index/*
 // @grant        none
-// @require      https://code.jquery.com/jquery-3.6.0.min.js
+// @require      https://code.jquery.com/jquery-3.6.0.min.js#sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=
 // ==/UserScript==
 
 (function() {


### PR DESCRIPTION
TamperMonkey does support Subresource Integrety, SRI hashes sha256 & md5 natively, making use of SRI should help ensure external js from jquery.com was not tampered with.

Ref:
https://www.tampermonkey.net/documentation.php?ext=dhdg&show=dhdg#Subresource_Integrity
https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity


ps.
You can verify the hash yourself locally using the commands listed on the Mozilla page (if changing the sha to be the 256 one supported by TM) or directly online via https://www.srihash.org/
ds.