### PR TITLE
Directly get date "today" as ISO 8601 string

### DIFF
--- a/pass-fur-alle.js
+++ b/pass-fur-alle.js
@@ -125,10 +125,7 @@
 
     function today() {
         var today = new Date();
-        var dd = String(today.getDate()).padStart(2, '0');
-        var mm = String(today.getMonth() + 1).padStart(2, '0');
-        var yyyy = today.getFullYear();
-        return yyyy + '-' + mm + '-' + dd;
+        return today.toISOString().slice(0,10);
     }
 
     function setButtonTexts() {


### PR DESCRIPTION
Avoid computing intermediate variables for year, month and day (possibly 0-padded) just to construct an ISO 8601 string of "YYYY-MM-DD".