### PR TITLE
Look at label to exclude booked slots

### DIFF
--- a/pass-fur-alle.js
+++ b/pass-fur-alle.js
@@ -75,7 +75,7 @@
                 }, timeSearchTimeout());
             } else {
                 log('Check for slot');
-                var availableTimeSlots = jQuery('.pointer.timecell.text-center[data-function="timeTableCell"]');
+                var availableTimeSlots = jQuery('.pointer.timecell.text-center[data-function="timeTableCell"][aria-label!="Bokad"]');
                 if (availableTimeSlots.length) {
                     log('Time found');
                     availableTimeSlots.first().click();


### PR DESCRIPTION
All slots now has the data-function 'timeTableCell', so when looking for available slots, booked slots are included. 
So by excluding all with label 'Bokad' (could look at background-color/color to solve the same issue) we only get the actual available slots.