### PR TITLE
Filter which passport offices return time slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ If you don't want to allow auto confirm of found time slot, change to `false`.
 
 `var autoConfirm = false;`
 
+### Only accept time from specific passport offices
+
+`var accept = 'Solna,Globen,Täby,Sthlm';`
+
+Set which passport offices you will accept time slots from. Separate offices with a comma.
+
 ## Run the damn thing
 
 * Go to the [booking page](https://polisen.se/tjanster-tillstand/pass-och-nationellt-id-kort/boka-tid-hitta-passexpedition/) and click on where you want to book.

--- a/pass-fur-alle.js
+++ b/pass-fur-alle.js
@@ -21,6 +21,7 @@
     var dateFrom = today();
     var dateTo = '2022-12-24';
     var autoConfirm = true;
+    var accept = ''; // For example: 'Solna,Globen,Täby,Sthlm'
 
     var datePickerElem = jQuery('#datepicker');
     if (!localStorage.getItem('TimeSearch')) {
@@ -79,6 +80,17 @@
             } else {
                 log('Check for slot');
                 var availableTimeSlots = jQuery('.pointer.timecell.text-center[data-function="timeTableCell"][aria-label!="Bokad"]');
+                
+                // Filter accepted passport offices
+                if(accept && accept.length) {
+                    availableTimeSlots = availableTimeSlots.filter(function() {
+                        var office = jQuery(this).closest(".timetable-cells").attr("headers");
+                        return accept.split(",").some(function(acceptedOffice) {
+                            return office.includes(acceptedOffice)
+                        });
+                    }) 
+                }
+
                 if (availableTimeSlots.length) {
                     log('Time found');
                     availableTimeSlots.first().click();


### PR DESCRIPTION
A setting to cherry pick which passport offices you will accept times from.

`var accept = ''; // For example: 'Solna,Globen,Täby,Sthlm'`
